### PR TITLE
feat: add Logfire MCP and external services docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,58 @@
+# =============================================================================
+# NanoClaw Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# The .env file is gitignored and never committed. Secrets are passed to
+# containers via the credential proxy — agents never see raw tokens.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Claude Authentication (REQUIRED — pick one)
+# -----------------------------------------------------------------------------
+
+# Option A: Claude Pro/Max subscription (recommended)
+# Run `claude setup-token` to get this value.
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Option B: Anthropic API key
+# Get one at https://console.anthropic.com/settings/keys
+# ANTHROPIC_API_KEY=
+
+# -----------------------------------------------------------------------------
+# MCP: MongoDB (optional)
+# -----------------------------------------------------------------------------
+# Read-only access to MongoDB Atlas databases.
+# The agent uses the official mongodb-mcp-server to query collections directly.
+#
+# Format: mongodb+srv://<user>:<pass>@<cluster>/<options>
+# Create a read-only database user in Atlas → Database Access for safety.
+MDB_MCP_CONNECTION_STRING=
+
+# -----------------------------------------------------------------------------
+# MCP: GitHub (optional)
+# -----------------------------------------------------------------------------
+# Personal Access Token for GitHub repo access via the GitHub MCP server.
+# The agent can read files, push commits, create PRs, and manage issues.
+#
+# Create at: https://github.com/settings/tokens?type=beta
+# Required scopes: Contents (read/write), Pull Requests (read/write)
+GITHUB_PERSONAL_ACCESS_TOKEN=
+
+# -----------------------------------------------------------------------------
+# MCP: Logfire (optional)
+# -----------------------------------------------------------------------------
+# Read token for Pydantic Logfire application performance monitoring.
+# The agent can query traces, find exceptions, and investigate performance.
+#
+# Create at: https://logfire.pydantic.dev → Settings → Read Tokens
+# Use a v2 multi-project token for access across all projects.
+LOGFIRE_READ_TOKEN=
+
+# -----------------------------------------------------------------------------
+# WhatsApp (optional — set by /add-whatsapp)
+# -----------------------------------------------------------------------------
+# Set to "true" if the bot has its own dedicated phone number (separate device).
+# Leave empty if using your personal WhatsApp number (self-chat or shared group).
 ASSISTANT_HAS_OWN_NUMBER=

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -409,7 +409,8 @@ async function runQuery(
         'NotebookEdit',
         'mcp__nanoclaw__*',
         'mcp__mongodb__*',
-        'mcp__github__*'
+        'mcp__github__*',
+        'mcp__logfire__*'
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
@@ -437,6 +438,13 @@ async function runQuery(
           args: ['stdio'],
           env: {
             GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GITHUB_PERSONAL_ACCESS_TOKEN || '',
+          },
+        },
+        logfire: {
+          type: 'http',
+          url: 'https://logfire-us.pydantic.dev/mcp',
+          headers: {
+            Authorization: `Bearer ${process.env.LOGFIRE_READ_TOKEN || ''}`,
           },
         },
       },

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -1,0 +1,114 @@
+# External Services & MCP Servers
+
+NanoClaw agents connect to external services via [MCP servers](https://modelcontextprotocol.io/) running inside the container. Each MCP server gives the agent a set of tools (prefixed with `mcp__<name>__`). Credentials are stored in `.env` on the host and passed to containers as environment variables — agents never see raw tokens directly.
+
+## How It Works
+
+```
+Host (.env)                    Container
+┌──────────────┐              ┌──────────────────────────────┐
+│ SECRET=xyz   │──env pass──▶ │ MCP Server (reads $SECRET)   │
+│              │   through    │   ↕                          │
+│              │              │ Claude Agent SDK              │
+│              │              │   → mcp__name__tool()         │
+└──────────────┘              └──────────────────────────────┘
+```
+
+**Adding a credential:** Set the variable in `.env`, add it to the `readEnvFile()` call in `src/container-runner.ts`, and add the MCP server config in `container/agent-runner/src/index.ts`.
+
+**Removing a service:** Delete the variable from `.env` and restart. The MCP server will start but fail to authenticate — the agent simply won't have those tools available.
+
+## Services
+
+### Claude (Required)
+
+The AI model that powers the agent. One of these is required.
+
+| Variable | Source |
+|----------|--------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | Run `claude setup-token` (Pro/Max subscription) |
+| `ANTHROPIC_API_KEY` | [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys) (API billing) |
+
+### MongoDB
+
+Read-only access to MongoDB Atlas databases. The agent can query any collection across all databases the connection string has access to.
+
+| Variable | Source |
+|----------|--------|
+| `MDB_MCP_CONNECTION_STRING` | MongoDB Atlas → Database Access → Create read-only user |
+
+**MCP server:** `mongodb-mcp-server` (run via npx)
+**Agent tools:** `mcp__mongodb__*` — query collections, list databases, inspect schemas
+**Runs with:** `--readOnly` flag (enforced server-side)
+
+**Tip:** Create a dedicated read-only database user in Atlas rather than reusing an admin account.
+
+### GitHub
+
+Full repository access via the official GitHub MCP server. The agent can read files, push commits, create/review PRs, manage issues, and more — across any repo the token has access to.
+
+| Variable | Source |
+|----------|--------|
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | [github.com/settings/tokens](https://github.com/settings/tokens?type=beta) (fine-grained PAT) |
+
+**MCP server:** `github-mcp-server` (binary, copied into container at build time)
+**Agent tools:** `mcp__github__*` — get/create/push files, create PRs, search repos, manage issues
+
+**Recommended PAT scopes:** Contents (read/write), Pull Requests (read/write), Issues (read/write). Add more scopes as needed for your workflow.
+
+### Logfire
+
+Application performance monitoring via [Pydantic Logfire](https://logfire.pydantic.dev). The agent can query trace data, find exceptions, investigate latency, and generate deep links to the Logfire UI.
+
+| Variable | Source |
+|----------|--------|
+| `LOGFIRE_READ_TOKEN` | Logfire → Settings → Read Tokens |
+
+**MCP server:** Remote HTTP server at `https://logfire-us.pydantic.dev/mcp` (no local process — token sent as Bearer header)
+**Agent tools:** `mcp__logfire__*` — `find_exceptions_in_file`, `arbitrary_query`, `logfire_link`, `schema_reference`
+
+**Tip:** Use a v2 multi-project token for access across all your Logfire projects from a single token. The API key needs `project:read` scope.
+
+## Adding a New MCP Server
+
+To give the agent access to a new service:
+
+1. **Add the credential** to `.env`:
+   ```
+   MY_SERVICE_TOKEN=xxx
+   ```
+
+2. **Pass it to containers** in `src/container-runner.ts` — add the variable name to the `readEnvFile()` array and add the `-e` flag:
+   ```typescript
+   const mcpEnv = readEnvFile([
+     // ... existing vars ...
+     'MY_SERVICE_TOKEN',
+   ]);
+   if (mcpEnv.MY_SERVICE_TOKEN) {
+     args.push('-e', `MY_SERVICE_TOKEN=${mcpEnv.MY_SERVICE_TOKEN}`);
+   }
+   ```
+
+3. **Configure the MCP server** in `container/agent-runner/src/index.ts` — add to `mcpServers`:
+   ```typescript
+   myservice: {
+     command: 'npx',
+     args: ['-y', 'my-service-mcp@latest'],
+     env: { MY_SERVICE_TOKEN: process.env.MY_SERVICE_TOKEN || '' },
+   },
+   ```
+
+4. **Allow the tools** — add `'mcp__myservice__*'` to the `allowedTools` array in the same file.
+
+5. **Install dependencies** if the MCP server needs a runtime not in the container (e.g., Python/uv for Python-based servers) — update `container/Dockerfile`.
+
+6. **Rebuild and restart:**
+   ```bash
+   ./container/build.sh          # Rebuild container image
+   npm run build                 # Rebuild host
+   # Sync agent-runner source to existing groups:
+   cp container/agent-runner/src/index.ts data/sessions/*/agent-runner-src/index.ts
+   launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
+   ```
+
+7. **Document it** — update `groups/global/CLAUDE.md` so the agent knows about the new tools, and add the variable to `.env.example`.

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -62,6 +62,23 @@ You have read-only access to MongoDB Atlas via the `mcp__mongodb__*` tools. Key 
 
 Entities carry cross-provider IDs (`boxlive_id`, `tapology_id`, `boxlive_url`, `tapology_url`) for linking records across sources.
 
+## Logfire (Application Performance Monitoring)
+
+You have read-only access to Logfire via the `mcp__logfire__*` tools. Use this to investigate application performance, find exceptions, and troubleshoot issues across Ben's services.
+
+**Projects:**
+
+| Project | What it covers |
+|---------|---------------|
+| `boxing-data-api` | FastAPI application logs — the Boxing Data REST API |
+| `boxing-data-pipelines` | Pipeline logs — both `combat-data-pipelines` (scraping) and `boxing-data-workflows` (ETL/merge). Both are Prefect-based |
+
+**Available tools:**
+- `find_exceptions_in_file` — Find exceptions/errors in a specific file
+- `arbitrary_query` — Run arbitrary SQL queries against Logfire trace data
+- `logfire_link` — Generate a deep link to the Logfire UI for a specific query
+- `schema_reference` — Get the schema for Logfire's trace data tables
+
 ## Your Workspace
 
 Files you create are saved in `/workspace/group/`. Use this for notes, research, or anything that should persist.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -226,6 +226,7 @@ function buildContainerArgs(
   const mcpEnv = readEnvFile([
     'MDB_MCP_CONNECTION_STRING',
     'GITHUB_PERSONAL_ACCESS_TOKEN',
+    'LOGFIRE_READ_TOKEN',
   ]);
   if (mcpEnv.MDB_MCP_CONNECTION_STRING) {
     args.push(
@@ -238,6 +239,9 @@ function buildContainerArgs(
       '-e',
       `GITHUB_PERSONAL_ACCESS_TOKEN=${mcpEnv.GITHUB_PERSONAL_ACCESS_TOKEN}`,
     );
+  }
+  if (mcpEnv.LOGFIRE_READ_TOKEN) {
+    args.push('-e', `LOGFIRE_READ_TOKEN=${mcpEnv.LOGFIRE_READ_TOKEN}`);
   }
 
   // Route API traffic through the credential proxy (containers never see real secrets)


### PR DESCRIPTION
## Summary
- Add Logfire application performance monitoring via remote HTTP MCP server (`logfire-us.pydantic.dev`) with Bearer token auth
- Add `docs/SERVICES.md` documenting all external services (Claude, MongoDB, GitHub, Logfire) and how to add new MCP servers
- Update `.env.example` with all required/optional environment variables and inline documentation

## Test plan
- [x] Send Andy a message asking to check Logfire for recent exceptions
- [x] Verify `LOGFIRE_READ_TOKEN` is passed through to the container
- [x] Confirm `.env.example` documents all current variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)