### PR TITLE
feat: pre-install mongodb-mcp-server in container image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -36,8 +36,9 @@ COPY --from=github-mcp /server/github-mcp-server /usr/local/bin/github-mcp-serve
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
-# Install agent-browser and claude-code globally
-RUN npm install -g agent-browser @anthropic-ai/claude-code
+# Install agent-browser, claude-code, and MCP servers globally
+# Pre-installing MCP servers avoids npx downloading them on every container start
+RUN npm install -g agent-browser @anthropic-ai/claude-code mongodb-mcp-server
 
 # Create app directory
 WORKDIR /app

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -427,8 +427,8 @@ async function runQuery(
           },
         },
         mongodb: {
-          command: 'npx',
-          args: ['-y', 'mongodb-mcp-server@latest', '--readOnly'],
+          command: 'mongodb-mcp-server',
+          args: ['--readOnly'],
           env: {
             MDB_MCP_CONNECTION_STRING: process.env.MDB_MCP_CONNECTION_STRING || '',
           },


### PR DESCRIPTION
## Summary
- Pre-install `mongodb-mcp-server` globally in Docker image instead of downloading via `npx -y` on every container start
- Use direct binary call (`mongodb-mcp-server`) instead of `npx`
- Eliminates ~43min first-message timeout caused by cold npm cache in ephemeral containers

## Test plan
- [ ] Verify faster container startup on fresh groups
- [ ] Confirm MongoDB MCP tools still work (`mcp__mongodb__*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)